### PR TITLE
Fixati alcuni crash per stringa vuota in login utente

### DIFF
--- a/src/gestori/GestoreUtenti.c
+++ b/src/gestori/GestoreUtenti.c
@@ -55,9 +55,9 @@ void infoUtenteConnesso(database db) {
 database loginUtente(database db) {
 	printf("\n\nEsecuzione Login ad Ampere");
 	int controllo=0, id=0;
+	char *username;
+	char *password;
 	while (controllo!=-1) {
-		char *username;
-		char *password;
 		pulisciBuffer();
 		if ((username = malloc(MAX_MEDIO))) {
 			printf("\nInserisci "C_GIALLO"username: "C_RESET);

--- a/src/sys/Utils.c
+++ b/src/sys/Utils.c
@@ -112,7 +112,7 @@ char* inputStringaSicuro(int lunghezza, char stringa[]) {
 	strtok(stringa, "\n");
 	// Controlla se l'utente non inserisce niente
 	if (stringa[0]=='\n') {
-		stringa = "N/A";
+		strcpy(stringa, "N/A");
 	}
 	return stringa;
 }


### PR DESCRIPTION
In C l'assegnazione a stringa crea un nuovo puntatore e lo inserisce nella variabile. Viene di conseguenza che il free falliva poichè non era la zona creata dalla malloc. Non ho ancora testato l'impatto globale della modifica, ma certamente risolve un crash all'inizio del programma quando si inserivano dei campi vuoti. Inoltre piccola ottimizzazione per non ridichiarare le variabili all'interno di un ciclo.